### PR TITLE
chore: update documentation build command in workflow and package.json

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,7 +33,7 @@ jobs:
         run: pnpm install
 
       - name: Build Docs
-        run: pnpm docs
+        run: pnpm build-docs
 
       - name: Setup Pages
         uses: actions/configure-pages@v4

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
 		"test": "vitest",
 		"test:watch": "vitest watch",
 		"type-check": "tsc --noEmit",
-		"docs": "typedoc",
+		"build-docs": "typedoc",
 		"prepublishOnly": "pnpm build",
 		"release": "changeset publish"
 	},


### PR DESCRIPTION
This pull request updates the documentation build process to use a more descriptive command name. The main change is renaming the script and its usage in the workflow configuration.

Documentation build process update:

* Renamed the `docs` script to `build-docs` in `package.json` for clarity and consistency.
* Updated the GitHub Actions workflow in `.github/workflows/docs.yml` to use `pnpm build-docs` instead of `pnpm docs` when building documentation.