### PR TITLE
Expand ComputeServerStats to cover full rhino.compute proxy/control s…

### DIFF
--- a/.changeset/server-stats-endpoints.md
+++ b/.changeset/server-stats-endpoints.md
@@ -1,0 +1,15 @@
+---
+'@selvajs/compute': minor
+---
+
+Expand `ComputeServerStats` to cover the full rhino.compute proxy/control surface (excluding the SELVA schema endpoints) so consumers no longer hand-roll fetches:
+
+- `getInstalledPlugins(kind)` — `/plugins/{gh,rhino}/installed`
+- `getServerTime()` — `/servertime`
+- `getIdleSpan()` — `/idlespan`
+- `launchChildren()` / `launchChild(port)` — `/launch-children`, `/launch-child`
+- `shutdownChildren(port?)` / `recycleChildren(port?)` — child-lifecycle controls
+- `purgeAllChildren()` — best-effort fleet-wide cache purge (loops `/cache/purge` across the round-robin pool; reports a `confident` flag, exact only at a single-child pool)
+- `getActiveChildren({ initialize })` — pass `initialize: false` for a passive count that does not spawn (and wake/bill) an idle server; `getServerStats()` now uses this passive read
+
+**Fix:** `isServerOnline()` now probes the proxy liveness root `/` instead of the non-existent `/healthcheck` route. The rhino.compute proxy never exposed `/healthcheck`; the old probe was forwarded to a child for an unknown path, so it reported reachability of a child rather than the proxy.

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
 		"contract:check": "node scripts/fetch-server-contract.mjs --check",
 		"test:seams": "vitest run tests/contract",
 		"test:seams:live": "RUN_LIVE_CONTRACT=1 vitest run tests/contract/server-contract.live.test.ts",
+		"test:stats:live": "vitest run tests/contract/compute-server-stats.live.test.ts",
 		"type-check": "tsc --noEmit",
 		"build-docs": "typedoc",
 		"prepublishOnly": "pnpm build",

--- a/src/core/server/__tests__/compute-server-stats.test.ts
+++ b/src/core/server/__tests__/compute-server-stats.test.ts
@@ -5,9 +5,10 @@
  * VektorNode/compute.rhino3d@Compute8) AND the failure-mode behavior, which was
  * previously the least-covered seam:
  *
- *   GET /healthcheck    → 200 (proxy MapHealthChecks). Client only reads .ok.
- *   GET /activechildren → plain-text integer (proxy writes ActiveComputeCount).
- *   GET /version        → { rhino, compute, git_sha } lowercase (proxied to a child).
+ *   GET /                    -> 200 "compute.rhino3d running" (proxy liveness root).
+ *   GET /activechildren      -> plain-text integer (proxy writes ActiveComputeCount).
+ *   GET /version             -> { rhino, compute, git_sha } lowercase (proxied to a child).
+ *   GET /plugins/*\/installed -> { name: version } map of non-core plugins.
  *
  * The client must DEGRADE GRACEFULLY on every failure (return null/false, never
  * throw) so a flaky monitor never crashes the caller — these tests pin exactly
@@ -46,15 +47,15 @@ function route(handlers: Record<string, () => Response>) {
 }
 
 describe('isServerOnline', () => {
-	it('is true when /healthcheck is 200', async () => {
-		route({ '/healthcheck': () => res('Healthy') });
+	it('is true when GET / is 200', async () => {
+		fetchMock.mockResolvedValue(res('compute.rhino3d running'));
 		const stats = new ComputeServerStats(SERVER);
 		await expect(stats.isServerOnline()).resolves.toBe(true);
 		await stats.dispose();
 	});
 
-	it('is false when /healthcheck is non-2xx', async () => {
-		route({ '/healthcheck': () => res('', { ok: false, status: 503 }) });
+	it('is false when GET / is non-2xx', async () => {
+		fetchMock.mockResolvedValue(res('', { ok: false, status: 503 }));
 		const stats = new ComputeServerStats(SERVER);
 		await expect(stats.isServerOnline()).resolves.toBe(false);
 		await stats.dispose();
@@ -67,11 +68,54 @@ describe('isServerOnline', () => {
 		await stats.dispose();
 	});
 
-	it('hits the /healthcheck endpoint (not a bare URL)', async () => {
-		route({ '/healthcheck': () => res('Healthy') });
+	it('probes the proxy root `/` (its real liveness route, not /healthcheck)', async () => {
+		fetchMock.mockResolvedValue(res('compute.rhino3d running'));
 		const stats = new ComputeServerStats(SERVER);
 		await stats.isServerOnline();
-		expect(fetchMock.mock.calls[0][0]).toBe(`${SERVER}/healthcheck`);
+		expect(fetchMock.mock.calls[0][0]).toBe(`${SERVER}/`);
+		await stats.dispose();
+	});
+});
+
+describe('getInstalledPlugins', () => {
+	it('returns the gh inventory by default', async () => {
+		route({
+			'/plugins/gh/installed': () => res(JSON.stringify({ Selva: '1.4.0', Pufferfish: '3.0' }))
+		});
+		const stats = new ComputeServerStats(SERVER);
+		await expect(stats.getInstalledPlugins()).resolves.toEqual({
+			Selva: '1.4.0',
+			Pufferfish: '3.0'
+		});
+		await stats.dispose();
+	});
+
+	it('hits /plugins/rhino/installed when kind is "rhino"', async () => {
+		route({ '/plugins/rhino/installed': () => res(JSON.stringify({ Bongo: '8.0' })) });
+		const stats = new ComputeServerStats(SERVER);
+		await expect(stats.getInstalledPlugins('rhino')).resolves.toEqual({ Bongo: '8.0' });
+		expect(fetchMock.mock.calls[0][0]).toBe(`${SERVER}/plugins/rhino/installed`);
+		await stats.dispose();
+	});
+
+	it('returns null on a non-2xx response', async () => {
+		route({ '/plugins/gh/installed': () => res('', { ok: false, status: 401 }) });
+		const stats = new ComputeServerStats(SERVER);
+		await expect(stats.getInstalledPlugins()).resolves.toBeNull();
+		await stats.dispose();
+	});
+
+	it('returns null on a non-JSON body', async () => {
+		route({ '/plugins/gh/installed': () => res('not json') });
+		const stats = new ComputeServerStats(SERVER);
+		await expect(stats.getInstalledPlugins()).resolves.toBeNull();
+		await stats.dispose();
+	});
+
+	it('returns null (not throwing) when the network rejects', async () => {
+		fetchMock.mockRejectedValue(new TypeError('fetch failed'));
+		const stats = new ComputeServerStats(SERVER);
+		await expect(stats.getInstalledPlugins()).resolves.toBeNull();
 		await stats.dispose();
 	});
 });
@@ -88,6 +132,14 @@ describe('getActiveChildren', () => {
 		route({ '/activechildren': () => res('  5\n') });
 		const stats = new ComputeServerStats(SERVER);
 		await expect(stats.getActiveChildren()).resolves.toBe(5);
+		await stats.dispose();
+	});
+
+	it('appends ?initialize=false for a passive read (no spawn)', async () => {
+		route({ '/activechildren?initialize=false': () => res('2') });
+		const stats = new ComputeServerStats(SERVER);
+		await expect(stats.getActiveChildren({ initialize: false })).resolves.toBe(2);
+		expect(fetchMock.mock.calls[0][0]).toBe(`${SERVER}/activechildren?initialize=false`);
 		await stats.dispose();
 	});
 
@@ -182,7 +234,7 @@ describe('API key header', () => {
 
 describe('getServerStats aggregation', () => {
 	it('returns only { isOnline: false } when offline (no extra round-trips)', async () => {
-		route({ '/healthcheck': () => res('', { ok: false, status: 503 }) });
+		route({ '/': () => res('', { ok: false, status: 503 }) });
 		const stats = new ComputeServerStats(SERVER);
 		await expect(stats.getServerStats()).resolves.toEqual({ isOnline: false });
 		await stats.dispose();
@@ -190,9 +242,10 @@ describe('getServerStats aggregation', () => {
 
 	it('aggregates version + activeChildren when online', async () => {
 		route({
-			'/healthcheck': () => res('Healthy'),
 			'/version': () => res(JSON.stringify({ rhino: '8', compute: '1', git_sha: null })),
-			'/activechildren': () => res('2')
+			// getServerStats reads the child count passively (no spawn).
+			'/activechildren?initialize=false': () => res('2'),
+			'/': () => res('compute.rhino3d running')
 		});
 		const stats = new ComputeServerStats(SERVER);
 		await expect(stats.getServerStats()).resolves.toEqual({
@@ -248,6 +301,157 @@ describe('purgeCache', () => {
 		fetchMock.mockRejectedValue(new TypeError('fetch failed'));
 		const stats = new ComputeServerStats(SERVER);
 		await expect(stats.purgeCache()).resolves.toBeNull();
+		await stats.dispose();
+	});
+});
+
+describe('purgeAllChildren', () => {
+	it('reads the passive child count and fires 2× purges', async () => {
+		let purges = 0;
+		route({
+			'/activechildren?initialize=false': () => res('3'),
+			'/cache/purge': () => {
+				purges++;
+				return res(JSON.stringify({ purged: 5 }));
+			}
+		});
+		const stats = new ComputeServerStats(SERVER);
+		const result = await stats.purgeAllChildren();
+		expect(result).toEqual({ totalPurged: 30, calls: 6, children: 3, confident: false });
+		expect(purges).toBe(6); // 2 × 3
+		// The count probe must be the non-spawning variant.
+		expect(fetchMock.mock.calls[0][0]).toBe(`${SERVER}/activechildren?initialize=false`);
+		await stats.dispose();
+	});
+
+	it('is confident at a single-child pool (one purge is exact)', async () => {
+		route({
+			'/activechildren?initialize=false': () => res('1'),
+			'/cache/purge': () => res(JSON.stringify({ purged: 7 }))
+		});
+		const stats = new ComputeServerStats(SERVER);
+		const result = await stats.purgeAllChildren();
+		expect(result).toEqual({ totalPurged: 14, calls: 2, children: 1, confident: true });
+		await stats.dispose();
+	});
+
+	it('short-circuits with zero work when no children are live', async () => {
+		let purges = 0;
+		route({
+			'/activechildren?initialize=false': () => res('0'),
+			'/cache/purge': () => {
+				purges++;
+				return res(JSON.stringify({ purged: 1 }));
+			}
+		});
+		const stats = new ComputeServerStats(SERVER);
+		const result = await stats.purgeAllChildren();
+		expect(result).toEqual({ totalPurged: 0, calls: 0, children: 0, confident: true });
+		expect(purges).toBe(0);
+		await stats.dispose();
+	});
+
+	it('returns null when the child count is unreadable', async () => {
+		route({ '/activechildren?initialize=false': () => res('', { ok: false, status: 503 }) });
+		const stats = new ComputeServerStats(SERVER);
+		await expect(stats.purgeAllChildren()).resolves.toBeNull();
+		await stats.dispose();
+	});
+
+	it('tolerates a failed purge mid-loop (skips it, keeps going)', async () => {
+		let n = 0;
+		route({
+			'/activechildren?initialize=false': () => res('2'),
+			'/cache/purge': () => {
+				n++;
+				// Second of the four calls fails; the rest return 4 each.
+				return n === 2 ? res('', { ok: false, status: 500 }) : res(JSON.stringify({ purged: 4 }));
+			}
+		});
+		const stats = new ComputeServerStats(SERVER);
+		const result = await stats.purgeAllChildren();
+		// 4 calls, one failed -> 3 × 4 purged.
+		expect(result).toEqual({ totalPurged: 12, calls: 4, children: 2, confident: false });
+		await stats.dispose();
+	});
+});
+
+describe('getServerTime', () => {
+	it('parses the JSON-quoted ISO timestamp into a Date', async () => {
+		route({ '/servertime': () => res('"2026-06-18T08:30:00Z"') });
+		const stats = new ComputeServerStats(SERVER);
+		const t = await stats.getServerTime();
+		expect(t?.toISOString()).toBe('2026-06-18T08:30:00.000Z');
+		await stats.dispose();
+	});
+
+	it('returns null on an unparseable body', async () => {
+		route({ '/servertime': () => res('"not-a-date"') });
+		const stats = new ComputeServerStats(SERVER);
+		await expect(stats.getServerTime()).resolves.toBeNull();
+		await stats.dispose();
+	});
+});
+
+describe('getIdleSpan', () => {
+	it('parses the numeric idle seconds', async () => {
+		route({ '/idlespan': () => res('42.5') });
+		const stats = new ComputeServerStats(SERVER);
+		await expect(stats.getIdleSpan()).resolves.toBe(42.5);
+		await stats.dispose();
+	});
+
+	it('returns null on a non-2xx response', async () => {
+		route({ '/idlespan': () => res('', { ok: false, status: 500 }) });
+		const stats = new ComputeServerStats(SERVER);
+		await expect(stats.getIdleSpan()).resolves.toBeNull();
+		await stats.dispose();
+	});
+});
+
+describe('child-lifecycle control', () => {
+	it('launchChildren POSTs and returns { spawned, active }', async () => {
+		route({ '/launch-children': () => res(JSON.stringify({ spawned: [6001, 6002], active: 2 })) });
+		const stats = new ComputeServerStats(SERVER);
+		await expect(stats.launchChildren()).resolves.toEqual({ spawned: [6001, 6002], active: 2 });
+		expect((fetchMock.mock.calls[0][1] as RequestInit).method).toBe('POST');
+		await stats.dispose();
+	});
+
+	it('launchChild appends ?port=N when a port is given', async () => {
+		route({ '/launch-child?port=6003': () => res(JSON.stringify({ spawned: [6003] })) });
+		const stats = new ComputeServerStats(SERVER);
+		await expect(stats.launchChild(6003)).resolves.toEqual({ spawned: [6003] });
+		expect(fetchMock.mock.calls[0][0]).toBe(`${SERVER}/launch-child?port=6003`);
+		await stats.dispose();
+	});
+
+	it('shutdownChildren targets all children when no port is given', async () => {
+		route({ '/shutdown-children': () => res(JSON.stringify({ shutdown: 3, active: 0 })) });
+		const stats = new ComputeServerStats(SERVER);
+		await expect(stats.shutdownChildren()).resolves.toEqual({ shutdown: 3, active: 0 });
+		expect(fetchMock.mock.calls[0][0]).toBe(`${SERVER}/shutdown-children`);
+		await stats.dispose();
+	});
+
+	it('recycleChildren returns { shutdown, spawned, active }', async () => {
+		route({
+			'/recycle-children': () =>
+				res(JSON.stringify({ shutdown: 2, spawned: [6001, 6002], active: 2 }))
+		});
+		const stats = new ComputeServerStats(SERVER);
+		await expect(stats.recycleChildren()).resolves.toEqual({
+			shutdown: 2,
+			spawned: [6001, 6002],
+			active: 2
+		});
+		await stats.dispose();
+	});
+
+	it('returns null (not throwing) when a control call rejects', async () => {
+		fetchMock.mockRejectedValue(new TypeError('fetch failed'));
+		const stats = new ComputeServerStats(SERVER);
+		await expect(stats.recycleChildren()).resolves.toBeNull();
 		await stats.dispose();
 	});
 });

--- a/src/core/server/compute-server-stats.ts
+++ b/src/core/server/compute-server-stats.ts
@@ -57,9 +57,9 @@ export default class ComputeServerStats {
 	/**
 	 * Check if the server is online.
 	 *
-	 * This is a single-sample probe: it returns `true` only on a 2xx from
-	 * `/healthcheck`, and `false` for every other outcome (non-2xx, network
-	 * error, or timeout). A cold or briefly-busy-but-up server can therefore
+	 * This is a single-sample probe: it returns `true` only on a 2xx from the
+	 * proxy liveness root `/`, and `false` for every other outcome (non-2xx,
+	 * network error, or timeout). A cold or briefly-busy-but-up server can therefore
 	 * read as offline — callers that gate on this (e.g. client construction)
 	 * should retry rather than treat a single `false` as authoritative.
 	 *
@@ -70,7 +70,11 @@ export default class ComputeServerStats {
 	public async isServerOnline(timeoutMs: number = 5000): Promise<boolean> {
 		this.ensureNotDisposed();
 
-		const url = `${this.serverUrl}/healthcheck`;
+		// The rhino.compute proxy has no `/healthcheck` route; its real liveness
+		// signal is `GET /`, which returns "compute.rhino3d running". Probing an
+		// unknown path would instead be forwarded to a child and only tells us the
+		// proxy can reach one.
+		const url = `${this.serverUrl}/`;
 		const init: RequestInit = { headers: this.buildHeaders(), method: 'GET' };
 		if (timeoutMs > 0) {
 			init.signal = AbortSignal.timeout(timeoutMs);
@@ -89,13 +93,26 @@ export default class ComputeServerStats {
 	/**
 	 * Get the number of active child processes on the server.
 	 *
+	 * By default the proxy's `/activechildren` endpoint will *spawn* children up
+	 * to the configured count if none are running, then report the count — which
+	 * wakes (and bills) an idle server. Pass `{ initialize: false }` for a passive
+	 * read that reports the current count without spawning; use this for
+	 * monitoring or before a purge/probe where you must not wake the server.
+	 *
+	 * @param options.initialize - When `false`, append `?initialize=false` so the
+	 *   server reports without spawning. Defaults to `true` (the server's default).
 	 * @returns Number of active children, or null if unavailable
 	 */
-	public async getActiveChildren(): Promise<number | null> {
+	public async getActiveChildren(options: { initialize?: boolean } = {}): Promise<number | null> {
 		this.ensureNotDisposed();
 
+		const { initialize = true } = options;
+		const url = initialize
+			? `${this.serverUrl}/activechildren`
+			: `${this.serverUrl}/activechildren?initialize=false`;
+
 		try {
-			const response = await fetch(`${this.serverUrl}/activechildren`, {
+			const response = await fetch(url, {
 				headers: this.buildHeaders()
 			});
 			if (!response.ok) {
@@ -160,6 +177,54 @@ export default class ComputeServerStats {
 	}
 
 	/**
+	 * Get the plugins installed on the server.
+	 *
+	 * Returns a `name → version` map of non-core plugins the server has loaded,
+	 * or `null` if the request failed. Pass `kind` to choose which inventory:
+	 * `'gh'` (default) lists Grasshopper add-on assemblies via
+	 * `/plugins/gh/installed`; `'rhino'` lists Rhino plugins via
+	 * `/plugins/rhino/installed`. Plugins that ship with Rhino / are core
+	 * libraries are excluded by the server.
+	 *
+	 * @param kind - `'gh'` for Grasshopper add-ons (default) or `'rhino'` for Rhino plugins.
+	 * @returns Map of plugin name to version, or `null` on failure.
+	 *
+	 * @example
+	 * ```ts
+	 * const gh = await stats.getInstalledPlugins();        // Grasshopper add-ons
+	 * const selvaVersion = gh?.['Selva'] ?? null;
+	 * ```
+	 */
+	public async getInstalledPlugins(
+		kind: 'gh' | 'rhino' = 'gh'
+	): Promise<Record<string, string> | null> {
+		this.ensureNotDisposed();
+
+		try {
+			const response = await fetch(`${this.serverUrl}/plugins/${kind}/installed`, {
+				headers: this.buildHeaders()
+			});
+
+			if (!response.ok) {
+				getLogger().warn(`[ComputeServerStats] Failed to fetch ${kind} plugins:`, response.status);
+				return null;
+			}
+
+			// Text-first so a non-JSON body can't throw "body already read".
+			const text = await response.text();
+			try {
+				const json = JSON.parse(text);
+				return json && typeof json === 'object' ? (json as Record<string, string>) : null;
+			} catch {
+				return null;
+			}
+		} catch (err) {
+			getLogger().warn(`[ComputeServerStats] Error fetching ${kind} plugins:`, err);
+			return null;
+		}
+	}
+
+	/**
 	 * Get comprehensive server statistics.
 	 * Fetches all available server information in parallel.
 	 *
@@ -178,9 +243,11 @@ export default class ComputeServerStats {
 			return { isOnline: false };
 		}
 
+		// Passive child count — never spawn from a stats read, or merely viewing
+		// server health would wake (and bill) an idle server.
 		const [version, activeChildren] = await Promise.all([
 			this.getVersion(),
-			this.getActiveChildren()
+			this.getActiveChildren({ initialize: false })
 		]);
 
 		return {
@@ -235,6 +302,231 @@ export default class ComputeServerStats {
 			}
 		} catch (err) {
 			getLogger().warn('[ComputeServerStats] Error purging cache:', err);
+			return null;
+		}
+	}
+
+	/**
+	 * Best-effort fleet-wide cache purge across a multi-child deployment.
+	 *
+	 * A single {@link purgeCache} POST is forwarded by the rhino.compute proxy to
+	 * just ONE round-robin-selected child, so the other children keep serving
+	 * stale cached solves. There is no proxy endpoint that addresses children
+	 * individually, so this method reads the active child count (passively, never
+	 * spawning) and fires `2 × count` sequential purges, relying on the proxy's
+	 * round-robin to spread the hits across the pool.
+	 *
+	 * **This is best-effort, not a guarantee.** Round-robin can revisit one child
+	 * and skip another; under concurrent traffic the rotation drifts. The result's
+	 * `confident` flag is `true` only when the server reports a single child (where
+	 * one purge is exact) — surface it so callers don't over-promise. For a hard
+	 * fleet-wide guarantee, run the deployment at `--childcount 1` or add a
+	 * server-side fan-out endpoint.
+	 *
+	 * @returns `{ totalPurged, calls, children, confident }`, or `null` if the
+	 *   child count couldn't be read (server unreachable). `totalPurged` sums the
+	 *   per-call counts; `calls` is how many purges were issued; `children` is the
+	 *   reported pool size; `confident` is `true` only at a single-child pool.
+	 *
+	 * @example
+	 * ```ts
+	 * const r = await stats.purgeAllChildren();
+	 * if (r && !r.confident) {
+	 *   console.warn(`Purged ~${r.totalPurged} across ${r.children} children (best-effort)`);
+	 * }
+	 * ```
+	 */
+	public async purgeAllChildren(): Promise<{
+		totalPurged: number;
+		calls: number;
+		children: number;
+		confident: boolean;
+	} | null> {
+		this.ensureNotDisposed();
+
+		// Passive read — must not spawn children just to purge them.
+		const children = await this.getActiveChildren({ initialize: false });
+		if (children === null) {
+			getLogger().warn('[ComputeServerStats] purgeAllChildren: could not read child count');
+			return null;
+		}
+
+		if (children === 0) {
+			// No live children means nothing is cached on the compute side.
+			return { totalPurged: 0, calls: 0, children: 0, confident: true };
+		}
+
+		// 2× the pool size gives round-robin a strong chance of reaching every
+		// child at least once. Sequential (not parallel) so the proxy advances its
+		// round-robin cursor one child per call rather than racing them onto one.
+		const calls = children * 2;
+		let totalPurged = 0;
+		for (let i = 0; i < calls; i++) {
+			const purged = await this.purgeCache();
+			if (purged !== null) totalPurged += purged;
+		}
+
+		return { totalPurged, calls, children, confident: children === 1 };
+	}
+
+	/**
+	 * Get the server's current UTC clock.
+	 *
+	 * GETs `/servertime`, which the server emits as a JSON-encoded ISO-8601
+	 * timestamp (e.g. `"2026-06-18T08:30:00Z"`). Useful for detecting clock skew
+	 * between caller and server. Returns `null` if the request failed or the body
+	 * isn't a parseable date.
+	 *
+	 * @returns A `Date` for the server's UTC time, or `null` on failure.
+	 */
+	public async getServerTime(): Promise<Date | null> {
+		this.ensureNotDisposed();
+
+		try {
+			const response = await fetch(`${this.serverUrl}/servertime`, {
+				headers: this.buildHeaders()
+			});
+			if (!response.ok) {
+				getLogger().warn('[ComputeServerStats] Failed to fetch server time:', response.status);
+				return null;
+			}
+
+			// Body is a JSON string ("2026-…Z"); strip surrounding quotes if present.
+			const text = (await response.text()).trim().replace(/^"|"$/g, '');
+			const date = new Date(text);
+			return isNaN(date.getTime()) ? null : date;
+		} catch (err) {
+			getLogger().warn('[ComputeServerStats] Error fetching server time:', err);
+			return null;
+		}
+	}
+
+	/**
+	 * Get how long the rhino.compute proxy has been idle.
+	 *
+	 * GETs `/idlespan` on the proxy, which returns the seconds elapsed since the
+	 * last request was forwarded to a compute child. This is a proxy-level metric
+	 * (not proxied to a child) used by autoscalers to decide when a node can be
+	 * drained. Returns `null` if unavailable.
+	 *
+	 * @returns Idle time in seconds, or `null` on failure.
+	 */
+	public async getIdleSpan(): Promise<number | null> {
+		this.ensureNotDisposed();
+
+		try {
+			const response = await fetch(`${this.serverUrl}/idlespan`, {
+				headers: this.buildHeaders()
+			});
+			if (!response.ok) {
+				getLogger().warn('[ComputeServerStats] Failed to fetch idle span:', response.status);
+				return null;
+			}
+			const seconds = parseFloat((await response.text()).trim());
+			return isNaN(seconds) ? null : seconds;
+		} catch (err) {
+			getLogger().warn('[ComputeServerStats] Error fetching idle span:', err);
+			return null;
+		}
+	}
+
+	/**
+	 * Fill the compute child pool up to the server's configured baseline.
+	 *
+	 * POSTs `/launch-children`. No-op when the pool is already at or above the
+	 * configured `--childcount`. Returns `{ spawned, active }` — how many children
+	 * were started and the resulting child count — or `null` on failure.
+	 *
+	 * To raise capacity above the baseline use {@link launchChild}; the baseline
+	 * itself can only be changed by restarting rhino.compute.
+	 *
+	 * @returns `{ spawned, active }`, or `null` on failure.
+	 */
+	public async launchChildren(): Promise<{ spawned: number[]; active: number } | null> {
+		return this.postJson('/launch-children');
+	}
+
+	/**
+	 * Add a single compute child to the pool, optionally on a specific port.
+	 *
+	 * POSTs `/launch-child` (with `?port=N` when `port` is given). Unlike
+	 * {@link launchChildren}, this can push the pool above the baseline, up to the
+	 * server's `MaxChildren` cap. Returns `{ spawned: [port] }` on success, or
+	 * `null` on failure (server replies 400 for a bad port, 409 if the port is in
+	 * use, 503 at the max-children cap).
+	 *
+	 * @param port - Optional specific port to launch on; otherwise the next free one.
+	 * @returns `{ spawned }` listing the launched port, or `null` on failure.
+	 */
+	public async launchChild(port?: number): Promise<{ spawned: number[] } | null> {
+		const path = port === undefined ? '/launch-child' : `/launch-child?port=${port}`;
+		return this.postJson(path);
+	}
+
+	/**
+	 * Gracefully shut down compute children without respawning them.
+	 *
+	 * POSTs `/shutdown-children`. With no `port` it shuts down every child; with
+	 * `port` it targets just that one. Children do not respawn, but the next
+	 * `/grasshopper` request auto-spawns the pool back to the baseline. Returns
+	 * `{ shutdown, active }` — how many were stopped and the remaining count — or
+	 * `null` on failure.
+	 *
+	 * @param port - Optional port to target; omit to shut down all children.
+	 * @returns `{ shutdown, active }`, or `null` on failure.
+	 */
+	public async shutdownChildren(
+		port?: number
+	): Promise<{ shutdown: number; active: number } | null> {
+		const path = port === undefined ? '/shutdown-children' : `/shutdown-children?port=${port}`;
+		return this.postJson(path);
+	}
+
+	/**
+	 * Shut down compute children and respawn replacements (rolling restart).
+	 *
+	 * POSTs `/recycle-children`. With no `port` it recycles every child; with
+	 * `port` it recycles just that one. The server recycles sequentially (each
+	 * replacement is serving before the next child is stopped) so the pool never
+	 * drops to zero mid-recycle. Returns `{ shutdown, spawned, active }`, or
+	 * `null` on failure.
+	 *
+	 * @param port - Optional port to target; omit to recycle all children.
+	 * @returns `{ shutdown, spawned, active }`, or `null` on failure.
+	 */
+	public async recycleChildren(
+		port?: number
+	): Promise<{ shutdown: number; spawned: number[]; active: number } | null> {
+		const path = port === undefined ? '/recycle-children' : `/recycle-children?port=${port}`;
+		return this.postJson(path);
+	}
+
+	/**
+	 * POST a control endpoint that replies with a JSON object and return it,
+	 * degrading to `null` on any non-2xx, non-JSON, or network failure. Shared by
+	 * the child-lifecycle methods so their failure semantics stay identical.
+	 */
+	private async postJson<T>(path: string): Promise<T | null> {
+		this.ensureNotDisposed();
+
+		try {
+			const response = await fetch(`${this.serverUrl}${path}`, {
+				method: 'POST',
+				headers: this.buildHeaders()
+			});
+			if (!response.ok) {
+				getLogger().warn(`[ComputeServerStats] POST ${path} failed:`, response.status);
+				return null;
+			}
+			// Text-first so a non-JSON body can't throw "body already read".
+			const text = await response.text();
+			try {
+				return JSON.parse(text) as T;
+			} catch {
+				return null;
+			}
+		} catch (err) {
+			getLogger().warn(`[ComputeServerStats] Error on POST ${path}:`, err);
 			return null;
 		}
 	}

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -57,9 +57,10 @@ export interface ComputeConfig {
 	 *
 	 * This should point at the `rhino.compute` front (the reverse proxy), not a
 	 * bare `compute.geometry` child process. `ComputeServerStats` relies on the
-	 * proxy-only endpoints `/healthcheck` and `/activechildren`; targeting a
-	 * bare `compute.geometry` would make `isServerOnline()` 404 even though
-	 * `/grasshopper` would still solve.
+	 * proxy liveness root `/` and proxy-only endpoints like `/activechildren`,
+	 * `/idlespan`, and the child-lifecycle controls; targeting a bare
+	 * `compute.geometry` would make those 404 even though `/grasshopper` would
+	 * still solve.
 	 */
 	serverUrl: string;
 	/** Optional API key for authenticating with the server (RhinoComputeKey) */

--- a/src/features/grasshopper/client/__tests__/grasshopper-client.e2e.test.ts
+++ b/src/features/grasshopper/client/__tests__/grasshopper-client.e2e.test.ts
@@ -5,8 +5,10 @@
  * fetchRhinoCompute → HTTP, and client.getIO() → fetchParsedDefinitionIO → the
  * input-type parser pipeline — without a live Compute server.
  *
- * fetch is routed by URL so each leg (healthcheck / grasshopper / io) is stubbed
- * independently, exercising the real URL building.
+ * fetch is routed by URL so each leg (liveness `/` / grasshopper / io) is stubbed
+ * independently, exercising the real URL building. The liveness probe hits the
+ * proxy root `/`, not `/healthcheck` (which the rhino.compute proxy doesn't
+ * expose) — see ComputeServerStats.isServerOnline.
  */
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import GrasshopperClient from '@/features/grasshopper/client/grasshopper-client';
@@ -32,8 +34,8 @@ function route(handlers: Record<string, () => Response>) {
 const onlineServer = () => createMockResponse({ status: 'healthy' });
 
 describe('GrasshopperClient.create', () => {
-	it('resolves when the server healthcheck is OK', async () => {
-		route({ '/healthcheck': onlineServer });
+	it('resolves when the server liveness probe is OK', async () => {
+		route({ '/': onlineServer });
 		const client = await GrasshopperClient.create({ serverUrl: SERVER });
 		expect(client).toBeInstanceOf(GrasshopperClient);
 		await client.dispose();
@@ -41,7 +43,7 @@ describe('GrasshopperClient.create', () => {
 
 	it('throws NETWORK_ERROR when the server is offline', async () => {
 		route({
-			'/healthcheck': () => createMockResponse({}, { ok: false, status: 503, statusText: 'down' })
+			'/': () => createMockResponse({}, { ok: false, status: 503, statusText: 'down' })
 		});
 		await expect(
 			GrasshopperClient.create({ serverUrl: SERVER, retry: { attempts: 0 } })
@@ -50,11 +52,11 @@ describe('GrasshopperClient.create', () => {
 		});
 	});
 
-	it('retries a flaky healthcheck and succeeds once it goes 2xx', async () => {
+	it('retries a flaky liveness probe and succeeds once it goes 2xx', async () => {
 		// Cold/busy-but-up server: first probe flickers 503, then recovers.
 		let calls = 0;
 		fetchMock.mockImplementation((url: string) => {
-			if (url.endsWith('/healthcheck')) {
+			if (url.endsWith('/')) {
 				calls += 1;
 				return Promise.resolve(
 					calls === 1
@@ -83,7 +85,7 @@ describe('GrasshopperClient.solve (e2e through transport)', () => {
 			warnings: []
 		};
 		route({
-			'/healthcheck': onlineServer,
+			'/': onlineServer,
 			'/grasshopper': () => createMockResponse(computeResponse)
 		});
 
@@ -104,7 +106,7 @@ describe('GrasshopperClient.solve (e2e through transport)', () => {
 	});
 
 	it('rejects an empty definition with INVALID_INPUT before any network call', async () => {
-		route({ '/healthcheck': onlineServer });
+		route({ '/': onlineServer });
 		const client = await GrasshopperClient.create({ serverUrl: SERVER });
 
 		await expect(client.solve('   ', [])).rejects.toMatchObject({ code: 'INVALID_INPUT' });
@@ -121,7 +123,7 @@ describe('GrasshopperClient.solve (e2e through transport)', () => {
 			warnings: []
 		};
 		route({
-			'/healthcheck': onlineServer,
+			'/': onlineServer,
 			'/grasshopper': () =>
 				createMockResponse(null, {
 					ok: false,
@@ -165,7 +167,7 @@ describe('GrasshopperClient.getIO (e2e through transport + parser pipeline)', ()
 			outputs: []
 		};
 		route({
-			'/healthcheck': onlineServer,
+			'/': onlineServer,
 			'/io': () => createMockResponse(ioResponse)
 		});
 

--- a/src/features/grasshopper/client/grasshopper-client.ts
+++ b/src/features/grasshopper/client/grasshopper-client.ts
@@ -63,8 +63,9 @@ export default class GrasshopperClient {
 	/**
 	 * Creates and initializes a GrasshopperClient with server validation.
 	 *
-	 * The pre-flight `/healthcheck` probe is a single-sample boolean gate that
-	 * reads a cold or briefly-busy-but-up server as offline. To avoid failing
+	 * The pre-flight liveness probe (a GET on the proxy root `/`) is a
+	 * single-sample boolean gate that reads a cold or briefly-busy-but-up server
+	 * as offline. To avoid failing
 	 * construction on that transient class, the probe is retried with a short
 	 * exponential backoff before giving up. Each probe is also bounded by a
 	 * timeout so a hung connection can't stall construction.
@@ -76,13 +77,13 @@ export default class GrasshopperClient {
 	static async create(config: GrasshopperComputeConfig): Promise<GrasshopperClient> {
 		const client = new GrasshopperClient(config);
 
-		// A single healthcheck miss isn't authoritative — a cold/busy-but-up
+		// A single liveness miss isn't authoritative — a cold/busy-but-up
 		// server flickers non-200. Retry a few times with backoff before failing.
 		const attempts = Math.max(1, (config.retry?.attempts ?? 2) + 1);
 		const baseDelayMs = config.retry?.baseDelayMs ?? 250;
 		const maxDelayMs = config.retry?.maxDelayMs ?? 1000;
 
-		// The healthcheck is a trivial GET — always bound it, independent of the
+		// The liveness probe is a trivial GET — always bound it, independent of the
 		// solve timeout (which may be 0 to allow arbitrarily long solves).
 		for (let attempt = 0; attempt < attempts; attempt++) {
 			if (await client.serverStats.isServerOnline()) {

--- a/tests/contract/compute-server-stats.live.test.ts
+++ b/tests/contract/compute-server-stats.live.test.ts
@@ -1,0 +1,94 @@
+/**
+ * LIVE smoke test — drives ComputeServerStats against a real, running compute
+ * server and asserts the READ-ONLY probes respond with the right wire shape.
+ *
+ * This is the test that catches what the mocked unit tests structurally cannot:
+ * a route that does not exist on the server (the reason `isServerOnline` was
+ * switched off `/healthcheck` onto the proxy root `/`). The unit suite mocks
+ * `fetch`, so it would happily pass against a phantom endpoint forever; this one
+ * actually hits the wire.
+ *
+ * Opt-in: self-skips unless COMPUTE_LIVE_URL is set, so the default `vitest run`
+ * and CI stay offline and deterministic. Point it at the rhino.compute PROXY
+ * (default port 6500), NOT a bare compute.geometry child (6001) — the proxy is
+ * where the liveness root `/`, `/idlespan` and `/activechildren` live. `/version`
+ * and `/plugins/*\/installed` work on either.
+ *
+ *   COMPUTE_LIVE_URL=http://localhost:6500 npx vitest run tests/contract/compute-server-stats.live.test.ts
+ *
+ * Pass COMPUTE_LIVE_KEY if the server has RHINO_COMPUTE_KEY configured.
+ *
+ * READ-ONLY ONLY: this suite never calls launchChildren/recycleChildren/
+ * shutdownChildren — those mutate the child pool. It is safe to run against any
+ * reachable server, including production.
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import ComputeServerStats from '../../src/core/server/compute-server-stats';
+
+const LIVE_URL = process.env.COMPUTE_LIVE_URL;
+const LIVE_KEY = process.env.COMPUTE_LIVE_KEY;
+
+// tests/setup.ts replaces global.fetch with a vi.fn(); restore Node's native
+// fetch for this suite so the probes actually reach the network. Captured here
+// (not at import time) and put back in afterAll so other suites keep the stub.
+let stubbedFetch: typeof globalThis.fetch;
+
+describe.runIf(Boolean(LIVE_URL))('ComputeServerStats — live read-only probes', () => {
+	let stats: ComputeServerStats;
+
+	beforeAll(() => {
+		// tests/setup.ts stashed Node's native fetch before installing the stub;
+		// swap it back for this suite so the probes reach the real network.
+		stubbedFetch = globalThis.fetch;
+		globalThis.fetch = (globalThis as { __nativeFetch?: typeof fetch }).__nativeFetch!;
+		stats = new ComputeServerStats(LIVE_URL!, LIVE_KEY);
+	});
+
+	afterAll(async () => {
+		await stats.dispose();
+		globalThis.fetch = stubbedFetch;
+	});
+
+	it('isServerOnline() is true against a running server', async () => {
+		await expect(stats.isServerOnline()).resolves.toBe(true);
+	});
+
+	it('getVersion() returns a rhino + compute version', async () => {
+		const version = await stats.getVersion();
+		expect(version).not.toBeNull();
+		expect(version!.rhino).toMatch(/\d+\./);
+		expect(typeof version!.compute).toBe('string');
+	});
+
+	it('getInstalledPlugins() returns a name -> version map', async () => {
+		const plugins = await stats.getInstalledPlugins('gh');
+		expect(plugins).not.toBeNull();
+		// Every value is a version string; the map may legitimately be empty on a
+		// vanilla server, so we only assert the shape, not specific plugins.
+		for (const v of Object.values(plugins!)) {
+			expect(typeof v).toBe('string');
+		}
+	});
+
+	it('getServerTime() returns a plausible UTC Date', async () => {
+		const t = await stats.getServerTime();
+		expect(t).toBeInstanceOf(Date);
+		// Within a day of the caller's clock — generous, just guards against a
+		// parse bug returning epoch-0 or NaN.
+		expect(Math.abs(Date.now() - t!.getTime())).toBeLessThan(24 * 60 * 60 * 1000);
+	});
+
+	it('getServerStats() aggregates online + version', async () => {
+		const all = await stats.getServerStats();
+		expect(all.isOnline).toBe(true);
+		expect(all.version?.rhino).toMatch(/\d+\./);
+	});
+});
+
+// Always-present marker so the file isn't reported as empty when skipped.
+describe('live stats test wiring', () => {
+	it('is opt-in via COMPUTE_LIVE_URL', () => {
+		expect(typeof LIVE_URL === 'string' || LIVE_URL === undefined).toBe(true);
+	});
+});

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -6,6 +6,10 @@ if (typeof window === 'undefined') {
 	global.window = {} as any;
 }
 
+// Stash Node's native fetch before stubbing so opt-in live suites can restore
+// it (see tests/contract/*.live.test.ts). Unit suites use the stub below.
+(globalThis as any).__nativeFetch = global.fetch;
+
 // Setup global mocks
 global.fetch = vi.fn();
 


### PR DESCRIPTION
…urface, adding endpoints for plugin retrieval, server time, idle span, child lifecycle controls, and a best-effort cache purge. Update isServerOnline to probe the proxy root instead of a non-existent healthcheck route. Add live tests for server stats functionality.