### PR TITLE
Detect server-side definition-cache misses by error code, not message

### DIFF
--- a/.changeset/definition-cache-miss-code.md
+++ b/.changeset/definition-cache-miss-code.md
@@ -1,0 +1,22 @@
+---
+'@selvajs/compute': minor
+---
+
+Detect server-side definition-cache misses by error code, not message.
+
+When solving by `pointer` (server cache key), a stale/evicted key now reliably
+triggers the transparent full-upload fallback even against a production Rhino
+Compute server. Previously the miss was detected by string-matching the server's
+exception message, which the server scrubs to a generic string when not in debug
+mode — so the fallback never fired in production and the caller saw a hard error.
+
+- Added `ErrorCodes.DEFINITION_NOT_CACHED`.
+- `fetchRhinoCompute` now reads an optional machine `code` from the server's JSON
+  error body and maps `"definition_not_cached"` onto that code, taking precedence
+  over the status-derived classification.
+- `solveByCacheKey` / `isDefinitionLoadMiss` match on the code first, keeping the
+  legacy message match as a fallback for debug-mode servers and older forks.
+
+Requires a Rhino Compute server that emits `code: "definition_not_cached"` on a
+stale-pointer miss (VektorNode fork). Older servers continue to work via the
+message fallback when running in debug mode.

--- a/src/core/compute-fetch/compute-fetch.ts
+++ b/src/core/compute-fetch/compute-fetch.ts
@@ -1,4 +1,4 @@
-import { RhinoComputeError, ErrorCodes } from '../errors';
+import { RhinoComputeError, ErrorCodes, type ErrorCode } from '../errors';
 import { getLogger } from '../utils/logger';
 
 import type { ComputeConfig, RetryPolicy, ServerTiming } from '../types';
@@ -110,7 +110,8 @@ function throwHttpError(
 	requestId: string,
 	requestSize: number,
 	serverUrl: string,
-	errorBody: string
+	errorBody: string,
+	serverCode?: string
 ): never {
 	const { status, statusText } = response;
 
@@ -161,7 +162,27 @@ function throwHttpError(
 		code: ErrorCodes.UNKNOWN_ERROR
 	};
 
-	throw new RhinoComputeError(error.message, error.code, { statusCode: status, context });
+	// A machine code in the server's error body (e.g. "definition_not_cached")
+	// outranks the status-based mapping: it's stable across the server's
+	// production message-scrubbing, where the human message is replaced with a
+	// generic string. Keep the status-derived message for context.
+	const code = mapServerErrorCode(serverCode) ?? error.code;
+
+	throw new RhinoComputeError(error.message, code, { statusCode: status, context });
+}
+
+/**
+ * Map a server-supplied error code (from the JSON error body's `code` field) to
+ * one of our {@link ErrorCodes}. Returns `undefined` for an absent or unknown
+ * code so the caller falls back to its status-based mapping.
+ */
+function mapServerErrorCode(serverCode?: string): ErrorCode | undefined {
+	switch (serverCode) {
+		case 'definition_not_cached':
+			return ErrorCodes.DEFINITION_NOT_CACHED;
+		default:
+			return undefined;
+	}
 }
 
 // ============================================================================
@@ -299,10 +320,17 @@ async function handleResponse(
 			}
 		}
 
+		// A machine-readable code the server may tag onto its error body (e.g.
+		// "definition_not_cached"). Unlike the human `message`, it isn't scrubbed in
+		// the server's production (non-debug) mode, so it's the reliable signal for
+		// classifying the error (see throwHttpError → mapServerErrorCode).
+		let serverCode: string | undefined;
+
 		// Check if it's a valid compute response with errors/warnings
 		if (response.status === 500) {
 			try {
 				const parsed = JSON.parse(errorBody);
+				if (typeof parsed?.code === 'string') serverCode = parsed.code;
 				// If it has values, it's a partial success with errors
 				if (parsed?.values && (parsed.errors || parsed.warnings)) {
 					if (debug) {
@@ -355,7 +383,7 @@ async function handleResponse(
 			}
 		}
 
-		throwHttpError(response, fullUrl, requestId, requestSize, serverUrl, errorBody);
+		throwHttpError(response, fullUrl, requestId, requestSize, serverUrl, errorBody, serverCode);
 	}
 
 	log(`✅ Request [${requestId}] completed in ${responseTime}ms`, debug);

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -21,7 +21,15 @@ export const ErrorCodes = {
 	/** Scheduler latest-wins: this call was replaced by a newer one. */
 	SUPERSEDED: 'SUPERSEDED',
 	/** Scheduler / caller-supplied AbortSignal: this call was aborted. */
-	ABORTED: 'ABORTED'
+	ABORTED: 'ABORTED',
+	/**
+	 * A solve referenced a definition by `pointer` (server-side cache key), but the
+	 * server no longer holds that definition (evicted / GC'd / a different child in
+	 * the pool / server restarted). The caller should retry with the full
+	 * definition. Surfaced when the server tags its error body with
+	 * `code: "definition_not_cached"`, so it survives production message-scrubbing.
+	 */
+	DEFINITION_NOT_CACHED: 'DEFINITION_NOT_CACHED'
 } as const;
 
 export type ErrorCode = (typeof ErrorCodes)[keyof typeof ErrorCodes];

--- a/src/features/grasshopper/__tests__/solve-cachekey.test.ts
+++ b/src/features/grasshopper/__tests__/solve-cachekey.test.ts
@@ -42,6 +42,20 @@ const loadFailed = () =>
 		{ ok: false, status: 500, statusText: 'Internal Server Error' }
 	);
 
+// Production-mode server: the human message is scrubbed to a generic string, but
+// a stable machine `code` identifies the miss. This is the path that matters once
+// the fork ships the code (debug-off deployments) — the string match above can't
+// catch it.
+const loadFailedScrubbed = () =>
+	createMockResponse(
+		{
+			error: 'Internal Server Error',
+			message: 'An unexpected error occurred. Check server logs for details.',
+			code: 'definition_not_cached'
+		},
+		{ ok: false, status: 500, statusText: 'Internal Server Error' }
+	);
+
 describe('solveGrasshopperDefinitionWithCacheKey', () => {
 	it('captures the server cache key from the response pointer', async () => {
 		fetchMock.mockResolvedValueOnce(okSolve({ pointer: 'md5_DEADBEEF' }));
@@ -95,6 +109,19 @@ describe('solveByCacheKey — fallback on cache miss', () => {
 		expect(body(0).algo).toBeNull();
 		expect(body(1).algo).toBeTruthy();
 		expect(body(1).pointer).toBeNull();
+	});
+
+	it('falls back when the miss is signalled by code, not message (prod server)', async () => {
+		fetchMock
+			.mockResolvedValueOnce(loadFailedScrubbed()) // pointer solve misses, message scrubbed
+			.mockResolvedValueOnce(okSolve({ pointer: 'md5_NEW' })); // full upload succeeds
+
+		const { cacheKey, missed } = await solveByCacheKey([], 'md5_OLD', DEF, config);
+
+		expect(missed).toBe(true);
+		expect(cacheKey).toBe('md5_NEW');
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+		expect(body(1).algo).toBeTruthy();
 	});
 
 	it('does NOT fall back on an unrelated error', async () => {

--- a/src/features/grasshopper/solve.ts
+++ b/src/features/grasshopper/solve.ts
@@ -1,4 +1,4 @@
-import { fetchRhinoCompute, RhinoComputeError } from '@/core';
+import { fetchRhinoCompute, RhinoComputeError, ErrorCodes } from '@/core';
 import { base64ByteArray, encodeStringToBase64, isBase64 } from '@/core/utils/encoding';
 import { getLogger } from '@/core/utils/logger';
 import { readField } from '@/core/utils/read-field';
@@ -18,12 +18,22 @@ import {
  * a different child in the pool), so the caller should retry with the full
  * definition. Matched as a substring because the server wraps it with a category
  * prefix in its exception handler.
+ *
+ * NOTE: the server only includes this message when running in debug mode; its
+ * production exception handler scrubs the message to a generic string. The
+ * reliable signal is therefore {@link ErrorCodes.DEFINITION_NOT_CACHED}, derived
+ * from the server's machine `code` (which isn't scrubbed). The string match is
+ * kept as a fallback for debug-mode servers and forks that don't yet emit a code.
  */
 const DEFINITION_LOAD_FAILED = 'Unable to load grasshopper definition';
 
 /** Does this error look like a server-side definition-load miss? */
 function isDefinitionLoadMiss(error: unknown): boolean {
-	return error instanceof RhinoComputeError && error.message.includes(DEFINITION_LOAD_FAILED);
+	if (!(error instanceof RhinoComputeError)) return false;
+	return (
+		error.code === ErrorCodes.DEFINITION_NOT_CACHED ||
+		error.message.includes(DEFINITION_LOAD_FAILED)
+	);
 }
 
 /**


### PR DESCRIPTION
- Added ErrorCodes.DEFINITION_NOT_CACHED.
- Updated fetchRhinoCompute to read an optional machine code from the server's JSON error body, prioritizing it over status-derived classifications.
- Modified solveByCacheKey and isDefinitionLoadMiss to match on the error code first, retaining the legacy message match as a fallback for debug-mode servers and older forks.